### PR TITLE
Surrounded cttPath in quotes to prevent issues with spaces in paths

### DIFF
--- a/xdt-transform.js
+++ b/xdt-transform.js
@@ -16,6 +16,7 @@ XdtTransform.prototype.transform = function (source, transform, destination) {
     /// <example> transform('[path-to-somewhere]\Web.config', '[path-to-somewhere]\Web.Transform.config', '[path-to-somewhere]\Web.config');</example>
     
     var cttPath = path.join(__dirname, cttExe);
+    cttPath = '"' + cttPath + '"';
     
     var s = '"s:##"'.replace("##", source);
     var t = '"t:##"'.replace("##", transform);


### PR DESCRIPTION
We had a few errors with the path to the ctt file containing spaces:

> " [Error: Command failed: C:\Windows\system32\cmd.exe /s /c "C:\Program Files (x86)\Jenkins\jobs\OurProjectName\node_modules\xdt-transform\bin\ctt.exe "s:../OurProject/Web.config" "t:../OurProject/Web.Release.config" "d:../OurProject/build-output/_PublishedWebsites/OurProject/Web.config" pw"
> 'C:\Program' is not recognized as an internal or external command,
> operable program or batch file."

This fix adds quotes around the file path so that paths containing spaces don't cause a problem.
